### PR TITLE
Avoid slow acks and nacks when finishing requests

### DIFF
--- a/vxaat/ussd.py
+++ b/vxaat/ussd.py
@@ -155,8 +155,14 @@ class AatUssdTransport(HttpRpcTransport):
 
         # Response failure
         if response_id is None:
-            yield self.publish_nack(message_id, self.RESPONSE_FAILURE_ERROR)
+            # we don't yield on this publish because if a message store is
+            # used, that causes the worker to wait for Riak before processing
+            # the message and responding to USSD messages is time critical.
+            self.publish_nack(message_id, self.RESPONSE_FAILURE_ERROR)
             return
 
-        yield self.publish_ack(user_message_id=message_id,
-                               sent_message_id=message_id)
+        # we don't yield on this publish because if a message store is
+        # used, that causes the worker to wait for Riak before processing
+        # the message and responding to USSD messages is time critical.
+        self.publish_ack(
+            user_message_id=message_id, sent_message_id=message_id)


### PR DESCRIPTION
Currently Vumi's message store struggles under load. While we're addressing this we'd like to have the AAT transport not wait for acks and nacks to be stored before completing processing outbound messages.